### PR TITLE
Fix/filter by ingredient

### DIFF
--- a/src/reciperepo.js
+++ b/src/reciperepo.js
@@ -3,26 +3,31 @@ const IngredientRepo = require('../src/IngredientRepo');
 
 class RecipeRepo {
   constructor(recipeData = []) {
-    this.recipes = recipeData.map(recipe => new Recipe(
-      recipe.id,
-      recipe.image,
-      recipe.ingredients,
-      recipe.instructions,
-      recipe.name,
-      recipe.tags
-    ))
+    this.recipes = recipeData.map(
+      recipe =>
+        new Recipe(
+          recipe.id,
+          recipe.image,
+          recipe.ingredients,
+          recipe.instructions,
+          recipe.name,
+          recipe.tags
+        )
+    );
   }
 
   filterRecipesByTag(tag) {
     const searchByTag = this.recipes.filter(recipe => {
       return recipe.tags.includes(tag);
-    })
+    });
     return searchByTag;
   }
 
   filterRecipesByName(recipeName) {
     const searchRecipeName = recipeName.toLowerCase();
-    return this.recipes.find(recipe => recipe.name.toLowerCase() === searchRecipeName);
+    return this.recipes.find(
+      recipe => recipe.name.toLowerCase() === searchRecipeName
+    );
   }
 
   filterRecipesByIngredients(ingredientData, ingredientName) {
@@ -31,7 +36,10 @@ class RecipeRepo {
     const filteredRecipes = [];
     this.recipes.filter(recipe => {
       recipe.ingredients.forEach(ingredient => {
-        if (ingredient.id === ingredientId) {
+        if (
+          ingredient.id === ingredientId &&
+          !filteredRecipes.includes(recipe)
+        ) {
           filteredRecipes.push(recipe);
         }
       });
@@ -40,13 +48,6 @@ class RecipeRepo {
   }
 }
 
-
-
-
-
-
-
-
-if (typeof module !== "undefined") {
+if (typeof module !== 'undefined') {
   module.exports = RecipeRepo;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -259,7 +259,6 @@ body {
 }
 
 @media screen and (max-width: 480px) {
-  
   .single-recipe {
     margin-top: 25px;
   }
@@ -267,6 +266,7 @@ body {
   .single-recipe-container {
     width: 95%;
   }
+
   .single-recipe-image {
     width: 95%;
   }
@@ -274,6 +274,7 @@ body {
   .single-recipe-list-container {
     margin: 0px;
   }
+}
 
 /* ------------------state---------------------------- */
 

--- a/test/reciperepo-test.js
+++ b/test/reciperepo-test.js
@@ -10,30 +10,30 @@ describe('RecipeRepo', () => {
     recipeList = new RecipeRepo();
     buffaloChicken = {
       id: 991136,
-      image: "https://spoonacular.com/recipeImages/991136-556x370.jpg",
+      image: 'https://spoonacular.com/recipeImages/991136-556x370.jpg',
       ingredients: [
         {
           id: 1001,
           quantity: {
             amount: 0.25,
-            unit: 'cup'
-          }
+            unit: 'cup',
+          },
         },
         {
           id: 98871,
           quantity: {
             amount: 12,
-            unit: 'unit'
-          }
+            unit: 'unit',
+          },
         },
       ],
       instructions: [
         { instruction: 'step 1', number: 1 },
         { instruction: 'step 2', number: 2 },
-        { instruction: 'step 3', number: 3 }
+        { instruction: 'step 3', number: 3 },
       ],
       name: 'Buffalo Chicken Example',
-      tags: ['lunch', 'main course', 'main dish', 'dinner']
+      tags: ['lunch', 'main course', 'main dish', 'dinner'],
     };
     beefNoodle = {
       id: 2,
@@ -43,51 +43,58 @@ describe('RecipeRepo', () => {
           id: 302,
           quantity: {
             amount: 10,
-            unit: 'cup'
-          }
+            unit: 'cup',
+          },
         },
         {
           id: 410,
           quantity: {
             amount: 3,
-            unit: 'tbs'
-          }
-        }
+            unit: 'tbs',
+          },
+        },
       ],
       instructions: [
         { instruction: 'step 1', number: 1 },
         { instruction: 'step 2', number: 2 },
-        { instruction: 'step 3', number: 3 }
+        { instruction: 'step 3', number: 3 },
       ],
       name: 'Beef Noodle',
       tags: ['noodles', 'main dish', 'hot dish'],
     };
     spaghetti = {
       id: 1234,
-      image: "https://spoonacular.com/recipeImages/991136-556x370.jpg",
+      image: 'https://spoonacular.com/recipeImages/991136-556x370.jpg',
       ingredients: [
         {
           id: 1001,
           quantity: {
             amount: 0.25,
-            unit: 'cup'
-          }
+            unit: 'cup',
+          },
         },
         {
           id: 91,
           quantity: {
             amount: 12,
-            unit: 'unit'
-          }
+            unit: 'unit',
+          },
+        },
+        {
+          id: 1001,
+          quantity: {
+            amount: 4,
+            unit: 'unit',
+          },
         },
       ],
       instructions: [
         { instruction: 'step 1', number: 1 },
         { instruction: 'step 2', number: 2 },
-        { instruction: 'step 3', number: 3 }
+        { instruction: 'step 3', number: 3 },
       ],
       name: 'Spaghetti',
-      tags: ['lunch', 'main course', 'main dish', 'dinner']
+      tags: ['lunch', 'main course', 'main dish', 'dinner'],
     };
     ingredientData = [
       {
@@ -116,10 +123,9 @@ describe('RecipeRepo', () => {
         estimatedCostInCents: 200,
       },
     ];
-  })
+  });
 
   describe('Properties', () => {
-
     it('should be a function', () => {
       expect(RecipeRepo).to.be.a('function');
     });
@@ -147,25 +153,24 @@ describe('RecipeRepo', () => {
       expect(recipeList.recipes[0]).to.be.an.instanceof(Recipe);
       expect(recipeList.recipes[1]).to.be.an.instanceof(Recipe);
     });
-  })
+  });
 
   describe('Methods', () => {
-
     it('should be able to filter recipes by a tag', () => {
       recipeList = new RecipeRepo([buffaloChicken, beefNoodle]);
-      const result = recipeList.filterRecipesByTag('noodles')
+      const result = recipeList.filterRecipesByTag('noodles');
 
       expect(result).deep.equal([beefNoodle]);
     });
 
     it('should be able to return multiple recipes if they share the same tag', () => {
       recipeList = new RecipeRepo([buffaloChicken, beefNoodle, spaghetti]);
-      const result = recipeList.filterRecipesByTag('dinner')
+      const result = recipeList.filterRecipesByTag('dinner');
 
       expect(result).deep.equal([buffaloChicken, spaghetti]);
     });
 
-    it('should return an empty array if tag isn\'t found', () => {
+    it("should return an empty array if tag isn't found", () => {
       recipeList = new RecipeRepo([buffaloChicken, beefNoodle]);
       const result = recipeList.filterRecipesByTag('snack');
 
@@ -186,7 +191,7 @@ describe('RecipeRepo', () => {
       expect(result).deep.equal(beefNoodle);
     });
 
-    it('should return undefined if the recipe doesn\'t exist', () => {
+    it("should return undefined if the recipe doesn't exist", () => {
       recipeList = new RecipeRepo([buffaloChicken, beefNoodle]);
       const result = recipeList.filterRecipesByName('Pork Tacos');
 
@@ -194,24 +199,43 @@ describe('RecipeRepo', () => {
     });
 
     it('should be able to filter recipes by an ingredient', () => {
-      recipeList = new RecipeRepo([buffaloChicken, beefNoodle, spaghetti])
-      const result = recipeList.filterRecipesByIngredients(ingredientData, 'hawaiian sweet rolls');
+      recipeList = new RecipeRepo([buffaloChicken, beefNoodle, spaghetti]);
+      const result = recipeList.filterRecipesByIngredients(
+        ingredientData,
+        'hawaiian sweet rolls'
+      );
 
       expect(result).deep.equal([buffaloChicken]);
     });
 
     it('should be able return all recipes that include an ingredient', () => {
-      recipeList = new RecipeRepo([buffaloChicken, beefNoodle, spaghetti])
-      const result = recipeList.filterRecipesByIngredients(ingredientData, 'butter');
+      recipeList = new RecipeRepo([buffaloChicken, beefNoodle, spaghetti]);
+      const result = recipeList.filterRecipesByIngredients(
+        ingredientData,
+        'butter'
+      );
+
+      expect(result).deep.equal([buffaloChicken, spaghetti]);
+    });
+
+    it('should not return duplicate recipes', () => {
+      recipeList = new RecipeRepo([buffaloChicken, beefNoodle, spaghetti]);
+      const result = recipeList.filterRecipesByIngredients(
+        ingredientData,
+        'butter'
+      );
 
       expect(result).deep.equal([buffaloChicken, spaghetti]);
     });
 
     it('should return an empty array if no ingredients are in a recipe', () => {
-      recipeList = new RecipeRepo([buffaloChicken, beefNoodle, spaghetti])
-      const result = recipeList.filterRecipesByIngredients(ingredientData, 'paprika');
+      recipeList = new RecipeRepo([buffaloChicken, beefNoodle, spaghetti]);
+      const result = recipeList.filterRecipesByIngredients(
+        ingredientData,
+        'paprika'
+      );
 
       expect(result).deep.equal([]);
     });
-  })
+  });
 });


### PR DESCRIPTION

## Is this a fix or a feature?
- fix
## What is the change?

## What does it fix?
- Duplicate recipes were being displayed to the user because the API data has duplicate ingredient id's with different amounts
- Functionality was added to the filterRecipeByIngredient method in the RecipeRepo class to check for duplicates
- When user searches by ingredient, they will see a unique list of recipes 
- Testing was added for this change as well
## Where should the reviewer start?
- reciperepo-test.js: lines: 221-229
- reciperepo.js: lines 38 -45
## How should this be tested?
- run npm test and all test should be passing
- open index.html, and filter by "butter", a unique list of recipes should appear, no duplicates

## Screenshots (if appropriate):
