### PR TITLE
Fix/recipe class duplicate ingredients

### DIFF
--- a/src/recipe.js
+++ b/src/recipe.js
@@ -25,6 +25,32 @@ class Recipe {
     return [...new Set(ingredientNames)];
   }
 
+  returnIngredientAmounts() {
+    const recipeIngredients = this.ingredients;
+    const amounts = recipeIngredients.reduce((ingredientAmounts, ingredient) => {
+      const ingredientInfo = ingredientAmounts[ingredient.id];
+          if(!ingredientInfo) {
+            ingredientAmounts[ingredient.id] = Object.values(ingredient.quantity); 
+          } else {
+            ingredientInfo.push(ingredient.quantity.amount, ingredient.quantity.unit)
+            let amount = 0; 
+             ingredientInfo.forEach(item => {
+              if(typeof(item) === "number") {
+                amount += item; 
+              }
+            })
+            ingredientAmounts[ingredient.id] = [amount, ingredient.quantity.unit] 
+          } 
+        return ingredientAmounts; 
+    }, {})
+    let ingredientAmounts = [];
+    Object.values(amounts).forEach(ingredientAmount => {
+        ingredientAmounts.push(ingredientAmount.join(' '))
+      }) 
+    ingredientAmounts = ingredientAmounts.reverse(); 
+    return ingredientAmounts
+  }
+
   calculateRecipeCost(ingredientData) {
     const recipeIngredients = this.findIngredients(ingredientData);
     const ingredientCost = recipeIngredients.map(

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -26,15 +26,14 @@ class Recipe {
   }
 
   returnIngredientAmounts() {
-      const recipeIngredients = this.ingredients;
-      const amounts = []
-      recipeIngredients.forEach(ingredient => {
-        const amount = Object.values(ingredient.quantity);
-        amounts.push(amount.join(" "));
-      })
-      return amounts
+    const recipeIngredients = this.ingredients;
+    const amounts = []
+    recipeIngredients.forEach(ingredient => {
+      const amount = Object.values(ingredient.quantity);
+      amounts.push(amount.join(" "));
+    })
+    return amounts
     }
-  }
 
    calculateRecipeCost(ingredientData) {
     const costPerUnit = [];

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -26,29 +26,14 @@ class Recipe {
   }
 
   returnIngredientAmounts() {
-    const recipeIngredients = this.ingredients;
-    const amounts = recipeIngredients.reduce((ingredientAmounts, ingredient) => {
-      const ingredientInfo = ingredientAmounts[ingredient.id];
-          if(!ingredientInfo) {
-            ingredientAmounts[ingredient.id] = Object.values(ingredient.quantity); 
-          } else {
-            ingredientInfo.push(ingredient.quantity.amount, ingredient.quantity.unit)
-            let amount = 0; 
-             ingredientInfo.forEach(item => {
-              if(typeof(item) === "number") {
-                amount += item; 
-              }
-            })
-            ingredientAmounts[ingredient.id] = [amount, ingredient.quantity.unit] 
-          } 
-        return ingredientAmounts; 
-    }, {})
-    let ingredientAmounts = [];
-    Object.values(amounts).forEach(ingredientAmount => {
-        ingredientAmounts.push(ingredientAmount.join(' '))
-      }) 
-    ingredientAmounts = ingredientAmounts.reverse(); 
-    return ingredientAmounts
+      const recipeIngredients = this.ingredients;
+      const amounts = []
+      recipeIngredients.forEach(ingredient => {
+        const amount = Object.values(ingredient.quantity);
+        amounts.push(amount.join(" "));
+      })
+      return amounts
+    }
   }
 
    calculateRecipeCost(ingredientData) {

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -11,20 +11,25 @@ class Recipe {
     const recipeIngredients = [];
     this.ingredients.forEach(recipeIngredient => {
       return recipeIngredients.push(
-        ingredientData.find(ingredient => recipeIngredient.id === ingredient.id));
+        ingredientData.find(ingredient => recipeIngredient.id === ingredient.id)
+      );
     });
     return recipeIngredients;
   }
 
   returnIngredientNames(ingredientData) {
     const recipeIngredients = this.findIngredients(ingredientData);
-    const ingredientNames = recipeIngredients.map(ingredient => ingredient.name);
-    return ingredientNames;
+    const ingredientNames = recipeIngredients.map(
+      ingredient => ingredient.name
+    );
+    return [...new Set(ingredientNames)];
   }
 
   calculateRecipeCost(ingredientData) {
     const recipeIngredients = this.findIngredients(ingredientData);
-    const ingredientCost = recipeIngredients.map(ingredientCost => ingredientCost.estimatedCostInCents);
+    const ingredientCost = recipeIngredients.map(
+      ingredientCost => ingredientCost.estimatedCostInCents
+    );
     const cost = ingredientCost.reduce((totalCost, ingredientCost) => {
       return totalCost + ingredientCost;
     }, 0);
@@ -36,6 +41,6 @@ class Recipe {
   }
 }
 
-if (typeof module !== "undefined") {
+if (typeof module !== 'undefined') {
   module.exports = Recipe;
 }

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -51,14 +51,12 @@ class Recipe {
     return ingredientAmounts
   }
 
-  calculateRecipeCost(ingredientData) {
-    const recipeIngredients = this.findIngredients(ingredientData);
-    const ingredientCost = recipeIngredients.map(
-      ingredientCost => ingredientCost.estimatedCostInCents
-    );
-    const cost = ingredientCost.reduce((totalCost, ingredientCost) => {
-      return totalCost + ingredientCost;
-    }, 0);
+   calculateRecipeCost(ingredientData) {
+    const costPerUnit = [];
+    this.ingredients.forEach(recipeIngredient => {
+      return costPerUnit.push((recipeIngredient.quantity.amount) * (ingredientData.find(ingredient => recipeIngredient.id === ingredient.id).estimatedCostInCents));
+    });
+    const cost = costPerUnit.reduce((totalCost, ingredientCost) => totalCost + ingredientCost, 0);
     return Number((cost / 100).toFixed(2));
   }
 

--- a/test/recipe-test.js
+++ b/test/recipe-test.js
@@ -169,7 +169,7 @@ describe('Recipe', () => {
 
   it('should return the total cost of all ingredients in recipe', () => {
     const totalCost = recipe1.calculateRecipeCost(ingredientData);
-    expect(totalCost).to.equal(16.68);
+    expect(totalCost).to.equal(19.20);
   });
 
   it('should return the instructions for the recipe', () => {

--- a/test/recipe-test.js
+++ b/test/recipe-test.js
@@ -161,9 +161,11 @@ describe('Recipe', () => {
     ]);
   });
 
-  it('should return the amount of each ingredient', () => {});
+  it('should return the amount of each ingredient', () => {
+    const ingredientAmount = recipe1.returnIngredientAmounts(ingredientData); 
 
-  // should return 1 amount here, account for duplicate ingredients
+    expect(ingredientAmount).to.deep.equal(['1.5 c', '0.5 tsp', '3 large'])
+  });
 
   it('should return the total cost of all ingredients in recipe', () => {
     const totalCost = recipe1.calculateRecipeCost(ingredientData);

--- a/test/recipe-test.js
+++ b/test/recipe-test.js
@@ -164,7 +164,7 @@ describe('Recipe', () => {
   it('should return the amount of each ingredient', () => {
     const ingredientAmount = recipe1.returnIngredientAmounts(ingredientData); 
 
-    expect(ingredientAmount).to.deep.equal(['1.5 c', '0.5 tsp', '3 large'])
+    expect(ingredientAmount).to.deep.equal(['1.5 c', '0.5 tsp', '1 large', '2 large'])
   });
 
   it('should return the total cost of all ingredients in recipe', () => {

--- a/test/recipe-test.js
+++ b/test/recipe-test.js
@@ -7,6 +7,7 @@ describe('Recipe', () => {
   let ingredient1;
   let ingredient2;
   let ingredient3;
+  let ingredient4;
   let instruction1;
   let instruction2;
   let instruction3;
@@ -63,6 +64,13 @@ describe('Recipe', () => {
         unit: 'large',
       },
     };
+    ingredient4 = {
+      id: 1123,
+      quantity: {
+        amount: 2,
+        unit: 'large',
+      },
+    };
 
     instruction1 = {
       instruction: 'Gather your ingredients',
@@ -81,7 +89,7 @@ describe('Recipe', () => {
     recipe1 = new Recipe(
       1,
       'https://spoonacular.com/recipeImages/595736-556x370.jpg',
-      [ingredient1, ingredient2, ingredient3],
+      [ingredient1, ingredient2, ingredient3, ingredient4],
       [instruction1, instruction2, instruction3],
       'Choclate Chip Cookies',
       ['dessert', 'starter', 'snack']
@@ -105,6 +113,7 @@ describe('Recipe', () => {
       ingredient1,
       ingredient2,
       ingredient3,
+      ingredient4,
     ]);
 
     expect(recipe1.instructions).to.deep.equal([
@@ -134,17 +143,27 @@ describe('Recipe', () => {
         name: 'eggs',
         estimatedCostInCents: 472,
       },
+      {
+        id: 1123,
+        name: 'eggs',
+        estimatedCostInCents: 472,
+      },
     ]);
   });
 
-  it('should return names of the ingredients', () => {
+  it('should return a unique list of ingredients', () => {
     const ingredientNames = recipe1.returnIngredientNames(ingredientData);
-    expect(ingredientNames).to.deep.equal([
+
+    expect(ingredientNames).deep.equal([
       'wheat flour',
       'bicarbonate of soda',
       'eggs',
     ]);
   });
+
+  it('should return the amount of each ingredient', () => {});
+
+  // should return 1 amount here, account for duplicate ingredients
 
   it('should return the total cost of all ingredients in recipe', () => {
     const totalCost = recipe1.calculateRecipeCost(ingredientData);

--- a/test/recipe-test.js
+++ b/test/recipe-test.js
@@ -167,7 +167,7 @@ describe('Recipe', () => {
 
   it('should return the total cost of all ingredients in recipe', () => {
     const totalCost = recipe1.calculateRecipeCost(ingredientData);
-    expect(totalCost).to.equal(11.96);
+    expect(totalCost).to.equal(16.68);
   });
 
   it('should return the instructions for the recipe', () => {


### PR DESCRIPTION

## Is this a fix or a feature?
- fix

## What is the change?

## What does it fix?
- This prevents duplicate ingredients from being listed, because some of the recipes have the same ingredient listed twice
- A method was added to return ingredient amounts as well. This method prevents duplicate amounts from being used
- updated data in test file to reflect duplicate ingredients that were found in the data
## Where should the reviewer start?
- recipe.js: lines 20 - 45
- recipe-test.js: 

## How should this be tested?
- run npm test in root directory, all tests should be passing

## Screenshots (if appropriate):
